### PR TITLE
Derive `Copy` for `StyledCharacter` and `Style`

### DIFF
--- a/src/styled_characters.rs
+++ b/src/styled_characters.rs
@@ -19,7 +19,7 @@ pub use super::{Message, SCREEN_HEIGHT, SCREEN_WIDTH};
 ///                       .background_color(Some(GameColor::Red))
 ///                       .font(Some(Font::BOLD | Font::UNDERLINED));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct Style {
     /// The color of the text.
     pub color: Option<GameColor>,
@@ -64,7 +64,7 @@ impl Style {
 /// StyledCharacter::new('x')
 ///                  .style(GameStyle::new().background_color(Some(GameColor::Black)));
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct StyledCharacter {
     /// This is the actual character that will be displayed on screen.
     pub c: char,


### PR DESCRIPTION
Idk if this won't be breaking the ideas you wanted to impose on student assignments, but from outside point of view it would be nice to have `Copy` trait for `StyledCharacter`.